### PR TITLE
Quick Compatability fix for Enigma. (1 of the 3 files)

### DIFF
--- a/Transformations/TransformationBuff.cs
+++ b/Transformations/TransformationBuff.cs
@@ -179,7 +179,7 @@ namespace DBZMOD.Transformations
 
         public void EnigmaEffects(Player player, float damageMultiplier)
         {
-            player.GetModPlayer<Laugicality.LaugicalityPlayer>(ModLoader.GetMod("Laugicality")).mysticDamage *= damageMultiplier;
+            player.GetModPlayer<Laugicality.LaugicalityPlayer>(ModLoader.GetMod("Laugicality")).MysticDamage *= damageMultiplier; //Compatability Fix: "M" was capitalized
         }
 
         public void BattleRodEffects(Player player, float damageMultiplier)


### PR DESCRIPTION
When Compiling the mod, a compatibility error for Laugicality may come up concerning the mysticDamage variable. This is just a quick fix for it.