### PR TITLE
Enigma Compatibility fix (1 of the 3 files)

### DIFF
--- a/Buffs/TiredDebuff.cs
+++ b/Buffs/TiredDebuff.cs
@@ -32,7 +32,7 @@ namespace DBZMOD.Buffs
         }
         public void EnigmaEffects(Player player)
         {
-            player.GetModPlayer<Laugicality.LaugicalityPlayer>(ModLoader.GetMod("Laugicality")).mysticDamage *= 0.8f;
+            player.GetModPlayer<Laugicality.LaugicalityPlayer>(ModLoader.GetMod("Laugicality")).MysticDamage *= 0.8f;
         }
         public void BattleRodEffects(Player player)
         {


### PR DESCRIPTION
When compiling the mod source, a compatibility error for Laugicality may come up concerning mysticDamage. This is just to fix it.