### PR TITLE
Compatability fix (1 of 3 files)

### DIFF
--- a/Players/MyPlayer.cs
+++ b/Players/MyPlayer.cs
@@ -1090,7 +1090,7 @@ namespace DBZMOD
 
         public void EnigmaEffects(Player player)
         {
-            player.GetModPlayer<Laugicality.LaugicalityPlayer>(ModLoader.GetMod("Laugicality")).mysticDamage *= PowerWishMulti();
+            player.GetModPlayer<Laugicality.LaugicalityPlayer>(ModLoader.GetMod("Laugicality")).MysticDamage *= PowerWishMulti();
         }
 
         public void BattleRodEffects(Player player)


### PR DESCRIPTION
Yet another hotfix for one of the files that concern the Laugicality compatiblity error that's encountered whilst compiling the mod. 

Main problem: Global Variable for "Mystic Damage" is depreciated.

Solution: Check for capitalization issues. ("m" was capitalized)